### PR TITLE
Terminus bugfix

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,13 @@
 [
-	{ "keys": ["backspace"], "command": "smart_backspace" },
+	{
+		"keys": ["backspace"],
+		"command": "smart_backspace",
+		"context": [
+			{
+				"key": "terminus_view",
+				"operand": false,
+			}
+		]
+	},
 	{ "keys": ["shift+backspace"], "command": "normal_backspace" }
 ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -5,7 +5,7 @@
 		"context": [
 			{
 				"key": "terminus_view",
-				"operand": false,
+				"operator": "not_equal",
 			}
 		]
 	},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,13 @@
 [
-	{ "keys": ["backspace"], "command": "smart_backspace" },
+	{
+		"keys": ["backspace"],
+		"command": "smart_backspace",
+		"context": [
+			{
+				"key": "terminus_view",
+				"operand": false,
+			}
+		]
+	},
 	{ "keys": ["shift+backspace"], "command": "normal_backspace" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -5,7 +5,7 @@
 		"context": [
 			{
 				"key": "terminus_view",
-				"operand": false,
+				"operator": "not_equal",
 			}
 		]
 	},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,13 @@
 [
-	{ "keys": ["backspace"], "command": "smart_backspace" },
+	{
+		"keys": ["backspace"],
+		"command": "smart_backspace",
+		"context": [
+			{
+				"key": "terminus_view",
+				"operand": false,
+			}
+		]
+	},
 	{ "keys": ["shift+backspace"], "command": "normal_backspace" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -5,7 +5,7 @@
 		"context": [
 			{
 				"key": "terminus_view",
-				"operand": false,
+				"operator": "not_equal",
 			}
 		]
 	},


### PR DESCRIPTION
For some reason backspaces don't work in terminus with Smart Backspace installed. I made a quick fix by editing the default key command files to exclude the terminus context on backspace.